### PR TITLE
Update PySimpleGUI version to 4.70.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ lmdb==1.4.1
 PyYAML==6.0.1
 omegaconf==2.1.2
 tqdm==4.66.1
-PySimpleGUI==4.55.1
+PySimpleGUI==4.70.1
 easydict==1.9
 scikit-learn==0.24.2
 pandas==2.0.3


### PR DESCRIPTION
When installing PySimpleGUI==4.55.1, the following exception is reported
```powershell
pip install PySimpleGUI==4.55.1
ERROR: Could not find a version that satisfies the requirement PySimpleGUI==4.55.1 (from versions: 4.60.5.0, 4.70.1, 5.0.0, 5.0.2, 5.0.3, 5.0.4, 5.0.5, 5.0.6)
ERROR: No matching distribution found for PySimpleGUI==4.55.1
```